### PR TITLE
Fixing bug for Android String.java implementation

### DIFF
--- a/src/main/java/com/eaio/stringsearch/StringSearch.java
+++ b/src/main/java/com/eaio/stringsearch/StringSearch.java
@@ -349,14 +349,16 @@ public abstract class StringSearch {
                     Field val = null, off = null;
 
                     for (int i = 0; i < stringFields.length; ++i) {
-                        if (stringFields[i].getType() == charArray) {
+                        final Field field = stringFields[i];
+                        if (field.getType() == charArray &&
+                        						java.lang.reflect.Modifier.isStatic(field.getModifiers()) == false) {
                             val = stringFields[i];
                             val.setAccessible(true);
                         }
-                        else if (stringFields[i].getType() == Integer.TYPE) {
-                            stringFields[i].setAccessible(true);
+                        else if (field.getType() == Integer.TYPE) {
+                            field.setAccessible(true);
 
-                            if (stringFields[i].getInt(shortString) == 0) {
+                            if (field.getInt(shortString) == 0) {
                                 off = stringFields[i];
                             }
 


### PR DESCRIPTION
In Android 5.1.1+ String.java has additional field:
Line: 88
    private static final char[] ASCII;
    static {
        ASCII = new char[128];
        for (int i = 0; i < ASCII.length; ++i) {
            ASCII[i] = (char) i;
        }
    }

And it is before
Line: 96
    private final char[] value;
and
Line: 98
    private final int offset;
